### PR TITLE
update ramel-codec version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pycodestyle==2.0.0
 pyflakes==1.2.3
 pytest==3.0.2
 PyYAML==3.12
-raml-codec==0.1.1
+raml-codec==0.1.2
 ramlfications==0.1.9
 requests==2.11.1
 six==1.10.0


### PR DESCRIPTION
raml-codec==0.1.1 is not being installed.  

fixes this issue: https://github.com/tomchristie/django-rest-raml/issues/2